### PR TITLE
ヘッダーコンポーネントの完成＆ボタンコンポーネントの名称変更

### DIFF
--- a/front/app/components/GrayRoundButton.tsx
+++ b/front/app/components/GrayRoundButton.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from "react";
 
-const IconButton = ({ icon: Icon, onClick }) => {
+const GrayRoundButton = ({ icon: Icon, onClick }) => {
   return (
     <button
       className="w-12 h-12 rounded-full hover:bg-gray-200 flex items-center justify-center"
@@ -11,4 +11,4 @@ const IconButton = ({ icon: Icon, onClick }) => {
   );
 };
 
-export default IconButton;
+export default GrayRoundButton;

--- a/front/app/components/GraySquareButton.tsx
+++ b/front/app/components/GraySquareButton.tsx
@@ -1,13 +1,12 @@
-import React from "react";
+import React from 'react';
 
-const GraySquareButton = ({
-  borderRadius = "rounded-none", icon: Icon, onClick }) => {
+const GraySquareButton = ({ borderRadius = "rounded-none", onClick, children }) => {
   return (
     <button
       className={`w-12 h-12 ${borderRadius} border border-gray-300 hover:bg-gray-200 flex items-center justify-center text-base`}
       onClick={onClick}
     >
-      <Icon boxSize={20} />
+      {children}
     </button>
   );
 };

--- a/front/app/components/GraySquareButton.tsx
+++ b/front/app/components/GraySquareButton.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const GraySquareButton = ({
+  borderRadius = "rounded-none", icon: Icon, onClick }) => {
+  return (
+    <button
+      className={`w-12 h-12 ${borderRadius} border border-gray-300 hover:bg-gray-200 flex items-center justify-center text-base`}
+      onClick={onClick}
+    >
+      <Icon boxSize={20} />
+    </button>
+  );
+};
+
+export default GraySquareButton;

--- a/front/app/components/Header.tsx
+++ b/front/app/components/Header.tsx
@@ -4,11 +4,14 @@ import Image from "next/image";
 import React from "react";
 import {
   HamburgerIcon,
-  ArrowLeftIcon,
-  ArrowRightIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CalendarIcon,
 } from "@chakra-ui/icons";
+import { BsGem, BsGraphUp, BsPersonFill } from "react-icons/bs";
 
-import IconButton from "./Button";
+import GrayRoundButton from "./GrayRoundButton";
+import GraySquareButton from "./GraySquareButton";
 
 const Header = () => {
   const handleButtonClick = () => {
@@ -17,9 +20,9 @@ const Header = () => {
   };
 
   return (
-    <header className="h-16 w-full flex items-center px-4">
+    <header className="h-16 w-full flex items-center px-4 border border-gray-200">
       <div className="order-first">
-        <IconButton icon={HamburgerIcon} onClick={handleButtonClick} />
+        <GrayRoundButton icon={HamburgerIcon} onClick={handleButtonClick} />
       </div>
       <div className="flex items-center ml-4">
         <Image src="/Q.png" alt="Q" width={32} height={32} />
@@ -28,9 +31,26 @@ const Header = () => {
           今日
         </button>
       </div>
-      <IconButton icon={ArrowLeftIcon} onClick={handleButtonClick} />
-      <IconButton icon={ArrowRightIcon} onClick={handleButtonClick} />
+      <GrayRoundButton icon={ChevronLeftIcon} onClick={handleButtonClick} />
+      <GrayRoundButton icon={ChevronRightIcon} onClick={handleButtonClick} />
       <p className="text-lg ml-8">2024年3月</p>
+      <div className="flex justify-end">
+        <GraySquareButton
+          icon={CalendarIcon}
+          onClick={handleButtonClick}
+          borderRadius="rounded-l-lg"
+        ></GraySquareButton>
+        <GraySquareButton
+          icon={BsGem}
+          onClick={handleButtonClick}
+        ></GraySquareButton>
+        <GraySquareButton
+          icon={BsGraphUp}
+          onClick={handleButtonClick}
+          borderRadius="rounded-r-lg"
+        ></GraySquareButton>
+        <GrayRoundButton icon={BsPersonFill} onClick={handleButtonClick} />
+      </div>
     </header>
   );
 };

--- a/front/app/components/Header.tsx
+++ b/front/app/components/Header.tsx
@@ -2,7 +2,12 @@
 
 import Image from "next/image";
 import React from "react";
-import { HamburgerIcon, ChevronLeftIcon, ChevronRightIcon, SettingsIcon } from "@chakra-ui/icons";
+import {
+  HamburgerIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  SettingsIcon,
+} from "@chakra-ui/icons";
 import { BsCalendar, BsGem, BsGraphUp } from "react-icons/bs";
 
 import GrayRoundButton from "./GrayRoundButton";
@@ -30,20 +35,24 @@ const Header = () => {
       <GrayRoundButton icon={ChevronRightIcon} onClick={handleButtonClick} />
       <p className="text-lg ml-8">2024年3月</p>
       <div className="md:ml-auto flex justify-center">
-        <GraySquareButton onClick={handleButtonClick} borderRadius="rounded-l-lg">
+        <GraySquareButton
+          onClick={handleButtonClick}
+          borderRadius="rounded-l-lg"
+        >
           <BsCalendar />
         </GraySquareButton>
         <GraySquareButton onClick={handleButtonClick}>
           <BsGem />
         </GraySquareButton>
-        <GraySquareButton onClick={handleButtonClick} borderRadius="rounded-r-lg">
+        <GraySquareButton
+          onClick={handleButtonClick}
+          borderRadius="rounded-r-lg"
+        >
           <BsGraphUp />
         </GraySquareButton>
         <div className="ml-8">
-        <GrayRoundButton icon={SettingsIcon} onClick={handleButtonClick} />
+          <GrayRoundButton icon={SettingsIcon} onClick={handleButtonClick} />
         </div>
-
-        
       </div>
     </header>
   );

--- a/front/app/components/Header.tsx
+++ b/front/app/components/Header.tsx
@@ -2,8 +2,8 @@
 
 import Image from "next/image";
 import React from "react";
-import { HamburgerIcon, ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
-import { BsCalendar, BsGem, BsGraphUp, BsPersonFill } from "react-icons/bs";
+import { HamburgerIcon, ChevronLeftIcon, ChevronRightIcon, SettingsIcon } from "@chakra-ui/icons";
+import { BsCalendar, BsGem, BsGraphUp } from "react-icons/bs";
 
 import GrayRoundButton from "./GrayRoundButton";
 import GraySquareButton from "./GraySquareButton";
@@ -29,7 +29,7 @@ const Header = () => {
       <GrayRoundButton icon={ChevronLeftIcon} onClick={handleButtonClick} />
       <GrayRoundButton icon={ChevronRightIcon} onClick={handleButtonClick} />
       <p className="text-lg ml-8">2024年3月</p>
-      <div className="flex justify-end">
+      <div className="md:ml-auto flex justify-center">
         <GraySquareButton onClick={handleButtonClick} borderRadius="rounded-l-lg">
           <BsCalendar />
         </GraySquareButton>
@@ -39,6 +39,11 @@ const Header = () => {
         <GraySquareButton onClick={handleButtonClick} borderRadius="rounded-r-lg">
           <BsGraphUp />
         </GraySquareButton>
+        <div className="ml-8">
+        <GrayRoundButton icon={SettingsIcon} onClick={handleButtonClick} />
+        </div>
+
+        
       </div>
     </header>
   );

--- a/front/app/components/Header.tsx
+++ b/front/app/components/Header.tsx
@@ -2,13 +2,8 @@
 
 import Image from "next/image";
 import React from "react";
-import {
-  HamburgerIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  CalendarIcon,
-} from "@chakra-ui/icons";
-import { BsGem, BsGraphUp, BsPersonFill } from "react-icons/bs";
+import { HamburgerIcon, ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
+import { BsCalendar, BsGem, BsGraphUp, BsPersonFill } from "react-icons/bs";
 
 import GrayRoundButton from "./GrayRoundButton";
 import GraySquareButton from "./GraySquareButton";
@@ -35,21 +30,15 @@ const Header = () => {
       <GrayRoundButton icon={ChevronRightIcon} onClick={handleButtonClick} />
       <p className="text-lg ml-8">2024年3月</p>
       <div className="flex justify-end">
-        <GraySquareButton
-          icon={CalendarIcon}
-          onClick={handleButtonClick}
-          borderRadius="rounded-l-lg"
-        ></GraySquareButton>
-        <GraySquareButton
-          icon={BsGem}
-          onClick={handleButtonClick}
-        ></GraySquareButton>
-        <GraySquareButton
-          icon={BsGraphUp}
-          onClick={handleButtonClick}
-          borderRadius="rounded-r-lg"
-        ></GraySquareButton>
-        <GrayRoundButton icon={BsPersonFill} onClick={handleButtonClick} />
+        <GraySquareButton onClick={handleButtonClick} borderRadius="rounded-l-lg">
+          <BsCalendar />
+        </GraySquareButton>
+        <GraySquareButton onClick={handleButtonClick}>
+          <BsGem />
+        </GraySquareButton>
+        <GraySquareButton onClick={handleButtonClick} borderRadius="rounded-r-lg">
+          <BsGraphUp />
+        </GraySquareButton>
       </div>
     </header>
   );

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,7 +11,8 @@
         "@chakra-ui/icons": "^2.1.1",
         "next": "14.1.3",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-icons": "^5.0.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4431,6 +4432,14 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "peer": true
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/front/package.json
+++ b/front/package.json
@@ -12,7 +12,8 @@
     "@chakra-ui/icons": "^2.1.1",
     "next": "14.1.3",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-icons": "^5.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/front/public/chevron-left.svg
+++ b/front/public/chevron-left.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
-</svg>

--- a/front/public/chevron-right.svg
+++ b/front/public/chevron-right.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
-</svg>


### PR DESCRIPTION
## プレビュー
<img width="1080" alt="image" src="https://github.com/elca-hub/hackit_2024/assets/134513305/183ca739-b7ca-4148-a839-3b033cc1571c">

## 変更点
<img width="455" alt="image" src="https://github.com/elca-hub/hackit_2024/assets/134513305/4a82a212-293d-48bf-b9a1-319631ab96e0">

- 左の３つのボタン（カレンダー用、期待値用、グラフ用）を追加
- ユーザー情報の変更用のボタンを追加

<img width="167" alt="image" src="https://github.com/elca-hub/hackit_2024/assets/134513305/fd370767-1ac0-4399-b0dc-0850af44e845">

- Button.tsx→GrayRoundButtonに変更
- GraySquareButtonの追加