### PR TITLE
deviseを用いたユーザのログイン・新規登録APIの本格実装

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,19 +1,19 @@
 class User < ApplicationRecord
         
-            include DeviseTokenAuth::Concerns::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  include DeviseTokenAuth::Concerns::User
 
-  before_save { email.downcase! }
-  EMAIL_FORMAT = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
-  validates :email, presence:   true,
-                    length:     { maximum: 255 },
-                    format:     { with: EMAIL_FORMAT },
-                    uniqueness: true
+  # before_save { email.downcase! }
+  # EMAIL_FORMAT = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+  # validates :email, presence:   true,
+  #                   length:     { maximum: 255 },
+  #                   format:     { with: EMAIL_FORMAT },
+  #                   uniqueness: true
 
-  has_secure_password
-  validates :password,  presence: true,
-                        length:   { minimum: 8 }
+  # has_secure_password
+  # validates :password,  presence: true,
+  #                       length:   { minimum: 8 }
 end

--- a/back/config/environments/development.rb
+++ b/back/config/environments/development.rb
@@ -67,5 +67,5 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
+  # config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/back/config/environments/test.rb
+++ b/back/config/environments/test.rb
@@ -60,5 +60,5 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
+  # config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/back/config/initializers/cors.rb
+++ b/back/config/initializers/cors.rb
@@ -7,10 +7,11 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "localhost:3000"
+    origins "*"
 
     resource "*",
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      expose: %i[token-type uid client access-token expiry]
   end
 end

--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = true
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,14 +42,14 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {
-  #   :'authorization' => 'Authorization',
-  #   :'access-token' => 'access-token',
-  #   :'client' => 'client',
-  #   :'expiry' => 'expiry',
-  #   :'uid' => 'uid',
-  #   :'token-type' => 'token-type'
-  # }
+  config.headers_names = {
+    :'authorization' => 'Authorization',
+    :'access-token' => 'access-token',
+    :'client' => 'client',
+    :'expiry' => 'expiry',
+    :'uid' => 'uid',
+    :'token-type' => 'token-type'
+  }
 
   # Makes it possible to use custom uid column
   # config.other_uid = "foo"
@@ -63,4 +63,5 @@ DeviseTokenAuth.setup do |config|
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
   # config.send_confirmation_email = true
+  config.require_client_password_reset_token = true
 end

--- a/back/config/initializers/wrap_parameters.rb
+++ b/back/config/initializers/wrap_parameters.rb
@@ -1,0 +1,3 @@
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters false 
+end

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -6,10 +6,12 @@ info:
 servers:
   - url: http://localhost:8003
     description: "モックサーバ"
-  - url: http://localhost:3030
+  - url: http://localhost:3000
     description: "ローカルサーバ"
 
 tags:
+  - name: "user"
+    description: "ユーザに関するAPI"
   - name: "calendar"
     description: "カレンダーに関するAPI"
   - name: "shift"
@@ -22,6 +24,53 @@ tags:
     description: "グラフに関するAPI"
 
 paths:
+  "/api/v1/auth/sign_in":
+    post:
+      tags:
+        - "user"
+      summary: "ログイン"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  example: "test@test.com"
+                password:
+                  type: string
+                  example: "password"
+      responses:
+        "200":
+          description: "ログインが成功した場合"
+
+  "/api/v1/auth":
+    post:
+      tags:
+        - "user"
+      summary: "新規登録"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  example: "test@test.com"
+                password:
+                  type: string
+                  example: "password"
+                password_confirmation:
+                  type: string
+                  example: "password"
+      responses:
+        "200":
+          description: "新規登録が成功した場合"
+
   "/calendar":
     get:
       tags:


### PR DESCRIPTION
# userのログイン・新規登録機能のAPI化

既にdeviseの方で生成されていたuserに関するログイン、新規登録APIの修正。

## 変更内容

### 追加

- swaggerにuserのログイン、新規登録を行うAPIの記述を追加

### 変更

- ログインページからログイン処理ができるように変更
  - 現在、ログイン成功時のリダイレクト先は`/`になっているが、後々変更する予定
  - ログインのエラー時にtoastを表示させるように変更

### 削除

- userモデルにあるメールアドレスのバリデーション関連の記述をコメントアウト

### 修正

- 既存のdeviseの設定ではnext.jsからAPIを叩いた際にエラーが発生する不具合を修正
- swaggerにて、ローカルサーバのポート名が`3030`になっていたミスを修正

<img width="1511" alt="スクリーンショット 2024-03-14 13 22 13" src="https://github.com/elca-hub/hackit_2024/assets/101086816/cc3c8e75-daed-4475-82a4-97342ee4b78c">

<img width="1511" alt="スクリーンショット 2024-03-14 13 22 21" src="https://github.com/elca-hub/hackit_2024/assets/101086816/d380ad46-bec7-4d50-8910-6edcfc6684e0">

ログインのエラー時にtoastを表示させるように変更。
<img width="1511" alt="スクリーンショット 2024-03-14 13 22 43" src="https://github.com/elca-hub/hackit_2024/assets/101086816/30865920-e209-4125-a9b6-8cc5ba95ca0c">

