### PR TITLE
APIサーバのホスト名を環境変数として保存

### DIFF
--- a/doc/how-to-use.md
+++ b/doc/how-to-use.md
@@ -39,3 +39,17 @@ dockerコンテナに反映させるためには↓↓
 ```bash
 docker compose run front npm install
 ```
+
+### APIサーバへの接続について
+
+APIサーバのホスト名は環境変数で参照すること！
+
+```javascript
+const data = await fetch(`${process.env.API_HOST}/api/v1/test`);
+```
+
+envファイル名は「**.env.development.local**」にし、以下の内容を記述すること。
+
+```text
+API_HOST=http://localhost:3000
+```

--- a/front/app/login/page.tsx
+++ b/front/app/login/page.tsx
@@ -49,7 +49,7 @@ export default function LoginPage() {
                 password: values.password,
               }
 
-              const response = await fetch("http://localhost:3000/api/v1/auth/sign_in", {
+              const response = await fetch(`${process.env.API_HOST}/api/v1/auth/sign_in`, {
                 method: "POST",
                 mode: "cors",
                 headers: {

--- a/front/app/register/steps/CheckValueStep.tsx
+++ b/front/app/register/steps/CheckValueStep.tsx
@@ -25,7 +25,7 @@ function CheckValueStep(props: {userData:InputData}) {
         goalAnnualIncome: props.userData.goalAnnualIncome
       };
 
-      const response = await fetch('http://localhost:3000/api/v1/auth', {
+      const response = await fetch(`${process.env.API_HOST}/api/v1/auth`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
# APIサーバのホスト名を環境変数として保存

## 内容

### 変更

- APIサーバのホスト名（`http://localhost:3000`）を環境変数として管理するように変更
  - デプロイ作業を円滑にするため
  - 開発環境下での設定方法については[使い方.md](https://github.com/elca-hub/hackit_2024/blob/main/doc/how-to-use.md)を参照