### PR TITLE
CHANGE:ヘッダーのアイコンサイズの変更とその他の修正

### DIFF
--- a/front/app/components/Circular.tsx
+++ b/front/app/components/Circular.tsx
@@ -1,6 +1,6 @@
 import { CircularProgress, CircularProgressLabel } from "@chakra-ui/react";
 
-const Circular = ({ size = "350px", progressSize = "6xl", goalSize = "lg", achievementSize = "4xl", mtsize = "1", progress = 40 }) => {
+const Circular = ({ size = "350px", progressSize = "6xl", goalSize = "base", achievementSize = "4xl", mtsize = "1", progress = 40 }) => {
   return (
     <CircularProgress value={progress} color="green.400" size={size} thickness="8px">
       <CircularProgressLabel>

--- a/front/app/components/GrayRoundButton.tsx
+++ b/front/app/components/GrayRoundButton.tsx
@@ -6,7 +6,7 @@ const GrayRoundButton = ({ icon: Icon, onClick }) => {
       className="w-12 h-12 rounded-full hover:bg-gray-200 flex items-center justify-center"
       onClick={onClick}
     >
-      <Icon boxSize={20} />
+      <Icon boxSize={8} />
     </button>
   );
 };

--- a/front/app/components/Header.tsx
+++ b/front/app/components/Header.tsx
@@ -32,13 +32,7 @@ export const Header = ({ isSideMenuOpen, toggleSideMenu }) => {
       <div className="flex items-center ml-4">
         <Image src="/Q.png" alt="Q" width={32} height={32} />
         <p className="text-3xl ml-4">Q-ON!</p>
-        <button className="w-16 h-12 rounded-lg border border-gray-300 hover:bg-gray-200 ml-8 mr-8 flex items-center justify-center text-base">
-          今日
-        </button>
       </div>
-      <GrayRoundButton icon={ChevronLeftIcon} onClick={handleButtonClick} />
-      <GrayRoundButton icon={ChevronRightIcon} onClick={handleButtonClick} />
-      <p className="text-lg ml-8">2024年3月</p>
       <div className="md:ml-auto flex justify-center">
         <GraySquareButton
           onClick={handleButtonClick}

--- a/front/app/components/Sidemenu.tsx
+++ b/front/app/components/Sidemenu.tsx
@@ -1,12 +1,5 @@
 import React from "react";
-import {
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
-  Button,
-  ChakraProvider,
-} from "@chakra-ui/react";
+import { Menu, MenuButton, MenuList, MenuItem, Button, ChakraProvider } from "@chakra-ui/react";
 import { AddIcon, ChevronDownIcon } from "@chakra-ui/icons";
 import SalaryList from "./SalaryList";
 import Circular from "./Circular";
@@ -40,7 +33,6 @@ const SideMenu = () => {
           <Circular
             size="250px"
             progressSize="4xl"
-            goalSize="base"
             achievementSize="2xl"
           ></Circular>
         </div>


### PR DESCRIPTION
## 変更点
- ヘッダーのアイコンのサイズを変更
![image](https://github.com/elca-hub/hackit_2024/assets/134513305/00427405-327f-4d43-aefd-7bb15e3a38bb)

- ヘッダーにあった不要な要素の削除
1. カレンダーの今日ボタンの削除
2. カレンダーの月の変更ボタンの削除
3. カレンダーの現在の年月表示を削除
![image](https://github.com/elca-hub/hackit_2024/assets/134513305/287a8fc3-47e1-4741-9d11-489718d9d90a)

## プレビュー
- サイドメニュー無ver
![image](https://github.com/elca-hub/hackit_2024/assets/134513305/5246cef0-b535-4f05-beaf-991db8325ca9)

- サイドメニュー在ver
![image](https://github.com/elca-hub/hackit_2024/assets/134513305/55dfaf87-cfaf-476e-a373-c8fb75a3eb23)

 