### PR TITLE
シフトコントローラーのフォーマット再指定と記述ミス修正

### DIFF
--- a/back/app/controllers/shifts_controller.rb
+++ b/back/app/controllers/shifts_controller.rb
@@ -2,23 +2,24 @@ class ShiftsController < ApplicationController
 
   require 'httpclient'
 
-def chekc_holiday(data)
-  client = HTTPClient.new
-  url = "http://api.national-holidays.jp/#{data}"
-  begin
-    response = client.get(url)
-    res_json = JSON.parse(response.body)
-    if res_json.has_key?("error") && res_json["error"] == "not_found"
-      return nil
-    elsif res_json.has_key?("name")
-      return res_json["name"]
-    else
-      Rails.logger.erorr "API response format error: #{res_json}"
-      return nil
+  def chekc_holiday(data)
+    client = HTTPClient.new
+    url = "http://api.national-holidays.jp/#{data}"
+    begin
+      response = client.get(url)
+      res_json = JSON.parse(response.body)
+      if res_json.has_key?("error") && res_json["error"] == "not_found"
+        return nil
+      elsif res_json.has_key?("name")
+        return res_json["name"]
+      else
+        Rails.logger.erorr "API response format error: #{res_json}"
+        return nil
+      end
+    rescue => e
+      return "取得に失敗しました"
+      Rails.logger.error "Error fetching holiday data: #{e}"
     end
-  rescue => e
-    return "取得に失敗しました"
-    Rails.logger.error "Error fetching holiday data: #{e}"
   end
 
   def show
@@ -26,7 +27,7 @@ def chekc_holiday(data)
     shift = Shift.find(params[:id])
 
     if user_id == part_time.user_id
-      render json: shift
+      render json: shift.to_json
     else
       render json: shift.errors, status: :unprocessable_entity
     end
@@ -38,7 +39,7 @@ def chekc_holiday(data)
     shift = Shift.new(shift_params.merge(holiday: holiday))
 
     if shift.save
-      render json: shift, include: :part_time, status: :created
+      render json: shift.to_json, include: :part_time, status: :created
     else
       render json: shift.errors, status: :unprocessable_entity
     end
@@ -49,7 +50,7 @@ def chekc_holiday(data)
     shift = Shift.find(params[:id])
 
     if part_time.user_id == user_id && shift.update(shift_params)
-      render json: shift, status: :ok
+      render json: shift.to_json, status: :ok
     else
       render json: shift.errors, status: :unprocessable_entity
     end
@@ -71,5 +72,4 @@ def chekc_holiday(data)
       :user_id
     )
   end
-end
 end


### PR DESCRIPTION
## 概要
シフトコントローラーにてフォーマットの指定が解除されていたので再指定
祝日のAPIを叩く関数部分のインデントがミスっており、結果`end`の記述箇所が異なっていたので修正